### PR TITLE
Tile layer nullsafety

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -513,7 +513,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       _throttleUpdate = StreamController<LatLng?>(sync: true);
       _throttleUpdate!.stream
           .transform(
-            util.throttleStreamTransformerWithTrailingCall<LatLng>(
+            util.throttleStreamTransformerWithTrailingCall<LatLng?>(
               options.updateInterval,
             ),
           )


### PR DESCRIPTION
The following _TypeError was thrown building RawGestureDetector(state: RawGestureDetectorState#23abb(gestures: [tap, long press, scale])):
type '_ControllerStream<LatLng?>' is not a subtype of type 'Stream<LatLng>' of 'stream'